### PR TITLE
Fix bug in which scope argument is treated as list instead of string

### DIFF
--- a/NDATools/clientscripts/vtcmd.py
+++ b/NDATools/clientscripts/vtcmd.py
@@ -127,7 +127,7 @@ def configure(args):
     if args.description:
         config.description = ' '.join(args.description)
     if args.scope:
-        config.scope = args.scope[0]
+        config.scope = args.scope
     if args.validationAPI:
         config.validation_api = args.validationAPI[0]
     if args.JSON:


### PR DESCRIPTION
My submission with custom scope was failing, not recognizing the column aliases I was using; when I tried validating using the online web tool, it validated successfully. So I ran with the pdb debugger and saw that the scope argument resolved to the first character of the scope or collection ID I was submitting under. When I made the proposed change, the data successfully validated, and I was able to submit using nda-tools.

I note that the argument parser for --scope indicates that the type is `str`, so it seemed a safe fix to create a pull request on.