### PR TITLE
Improve AWS policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ For non-public buckets, this will require an update to the bucket policy. The fo
     "Principal": {
         "AWS": "arn:aws:iam::618523879050:federated-user/<username>"        
     },
-    "Action": "s3:PutObject*",
+    "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject*"
+    ],
     "Resource": "arn:aws:s3:::<your-s3-bucket>/*"
 }
 ```
@@ -306,7 +309,16 @@ The following statement should be added to your key's policy:
         "AWS":  "arn:aws:iam::618523879050:user/DownloadManager"
     },
     "Action": ["kms:GenerateDataKey","kms:Decrypt"],
-    "Resource": "*"
+    "Resource": "*",
+    "Condition": {
+        "StringEquals": {
+            "kms:CallerAccount": "618523879050",
+            "kms:ViaService": "s3.us-east-1.amazonaws.com"
+        },
+        "StringLike": {
+            "kms:EncryptionContext:aws:s3:arn": "arn:aws:s3:::<bucket_name>"
+        }
+    }
 }
 ```
 ## Further Assistance


### PR DESCRIPTION
I have 2 suggested changes for provided S3/KMS policies.

* When performing multipart upload, the underlying library might need to abort the copy/upload, which requires a different action in the policy document. I haven't encountered any error caused by the missing the `s3:AbortMultipartUpload` action, possibly because the threshold is set to 5GiB.
* The scope of the KMS policy is too broad. We could narrow it down and only allow the NDA account to use it with a specific S3 bucket. I tested this rule and can confirm it still works. 

