### PR TITLE
Note default values of -wt and -bc in help message

### DIFF
--- a/NDATools/clientscripts/vtcmd.py
+++ b/NDATools/clientscripts/vtcmd.py
@@ -86,10 +86,10 @@ def parse_args():
                         help='Flag whether to additionally download validation results in JSON format.')
 
     parser.add_argument('-wt', '--workerThreads', metavar='<arg>', type=int, action='store',
-                        help='Number of worker threads')
+                        help='Number of worker threads, default is multiprocessing.cpu_count()-1')
 
     parser.add_argument('-bc', '--batch', metavar='<arg>', type=int, action='store',
-                        help='Batch size')
+                        help='Batch size, default is 10000')
 
     parser.add_argument('--hideProgress', action='store_true', help='Hides upload/processing progress')
 


### PR DESCRIPTION
Both defaults are defined in https://github.com/NDAR/nda-tools/blob/aa89ec26de21f04679dec702c054f19ef48726d4/NDATools/Submission.py#L52-L57

Also, may be clarify where this batch size apply.