### PR TITLE
Remove sys.exit from version check.

### DIFF
--- a/NDATools/__init__.py
+++ b/NDATools/__init__.py
@@ -44,7 +44,6 @@ def check_version():
     if parse(NDATools.__version__) < parse(NDATools.pypi_version):
         print("Your version of nda-tools is out of date. Please upgrade to the latest version ({}) from PyPi or GitHub and "
               "try again. \n\tTo upgrade using pip, run: \r\npip install nda-tools=={}".format(NDATools.pypi_version, NDATools.pypi_version))
-        sys.exit(1)
 
     NDATools.version_checked = True
 


### PR DESCRIPTION
Removed sys.exit from check_version. Now when the version is out of date, a warning is printed, but the code continues.